### PR TITLE
Remove pre-line to preserve indentation in <pre> blocks.

### DIFF
--- a/static/css/pygment.css
+++ b/static/css/pygment.css
@@ -3,7 +3,6 @@
   padding: .5em;
   background: rgba(253,251,228,0.64);
   color: #657b83;
-  white-space: pre-line
 }
 
 .hll {


### PR DESCRIPTION
Using `pre-line` collapses multiple white spaces into one, which breaks indentation in code blocks. I think the CSS default value for `pre` works fine.
